### PR TITLE
Make modules schema independent

### DIFF
--- a/source/database/build-nature/src/data/sql/build_dataset_24.sql
+++ b/source/database/build-nature/src/data/sql/build_dataset_24.sql
@@ -1,5 +1,5 @@
-{import_common 'database-modules/nature_areas/dataset_24.sql'}
-{import_common 'database-modules/nature_habitats_and_species/supplied_24.sql'}
+{import_common_into_schema 'database-modules/nature_areas/dataset_24.sql', 'nature'}
+{import_common_into_schema 'database-modules/nature_habitats_and_species/supplied_24.sql', 'nature'}
 
-{import_common 'database-modules/build_nature/build.sql'}
-{import_common 'database-modules/build_nature/store.sql'}
+{import_common_into_schema 'database-modules/build_nature/build.sql', 'nature'}
+{import_common_into_schema 'database-modules/build_nature/store.sql', 'nature'}

--- a/source/database/build-nature/src/main/sql/structure.sql
+++ b/source/database/build-nature/src/main/sql/structure.sql
@@ -6,6 +6,8 @@ CREATE EXTENSION postgis;
 
 {import_common 'database-modules/aerius-general/'}
 
-{import_common 'database-modules/nature_areas/'}
-{import_common 'database-modules/nature_habitats_and_species/'}
-{import_common 'database-modules/build_nature/'}
+CREATE SCHEMA nature;
+
+{import_common_into_schema 'database-modules/nature_areas/', 'nature'}
+{import_common_into_schema 'database-modules/nature_habitats_and_species/', 'nature'}
+{import_common_into_schema 'database-modules/build_nature/', 'nature'}

--- a/source/modules/src/data/sql/database-modules/build_nature/build.sql
+++ b/source/modules/src/data/sql/database-modules/build_nature/build.sql
@@ -1,23 +1,23 @@
 --
 -- habitats and species
 --
-SELECT system.raise_notice('Build: nature.habitats @ ' || timeofday());
+SELECT system.raise_notice('Build: habitats @ ' || timeofday());
 BEGIN;
-	INSERT INTO nature.habitats(assessment_area_id, habitat_type_id, habitat_coverage, geometry)
+	INSERT INTO habitats(assessment_area_id, habitat_type_id, habitat_coverage, geometry)
 		SELECT assessment_area_id, habitat_type_id, habitat_coverage, geometry
-		FROM nature.build_habitats_view;
+		FROM build_habitats_view;
 COMMIT;
 
-SELECT system.raise_notice('Build: nature.relevant_habitat_areas @ ' || timeofday());
+SELECT system.raise_notice('Build: relevant_habitat_areas @ ' || timeofday());
 BEGIN;
-	INSERT INTO nature.relevant_habitat_areas(assessment_area_id, habitat_area_id, habitat_type_id, coverage, geometry)
+	INSERT INTO relevant_habitat_areas(assessment_area_id, habitat_area_id, habitat_type_id, coverage, geometry)
 		SELECT assessment_area_id, habitat_area_id, habitat_type_id, coverage, geometry
-		FROM nature.build_relevant_habitat_areas_view;
+		FROM build_relevant_habitat_areas_view;
 COMMIT;
 
-SELECT system.raise_notice('Build: nature.relevant_habitats @ ' || timeofday());
+SELECT system.raise_notice('Build: relevant_habitats @ ' || timeofday());
 BEGIN;
-	INSERT INTO nature.relevant_habitats(assessment_area_id, habitat_type_id, habitat_coverage, geometry)
+	INSERT INTO relevant_habitats(assessment_area_id, habitat_type_id, habitat_coverage, geometry)
 		SELECT assessment_area_id, habitat_type_id, habitat_coverage, geometry
-		FROM nature.build_relevant_habitats_view;
+		FROM build_relevant_habitats_view;
 COMMIT;

--- a/source/modules/src/data/sql/database-modules/build_nature/store.sql
+++ b/source/modules/src/data/sql/database-modules/build_nature/store.sql
@@ -1,6 +1,6 @@
 --
 -- habitats and species
 --
-BEGIN; SELECT system.store_table('nature.relevant_habitat_areas', '{data_folder}/export/{tablename}_{datesuffix}.txt'); COMMIT;
-BEGIN; SELECT system.store_table('nature.habitats', '{data_folder}/export/{tablename}_{datesuffix}.txt'); COMMIT;
-BEGIN; SELECT system.store_table('nature.relevant_habitats', '{data_folder}/export/{tablename}_{datesuffix}.txt'); COMMIT;
+BEGIN; SELECT system.store_table('relevant_habitat_areas', '{data_folder}/export/{tablename}_{datesuffix}.txt'); COMMIT;
+BEGIN; SELECT system.store_table('habitats', '{data_folder}/export/{tablename}_{datesuffix}.txt'); COMMIT;
+BEGIN; SELECT system.store_table('relevant_habitats', '{data_folder}/export/{tablename}_{datesuffix}.txt'); COMMIT;

--- a/source/modules/src/data/sql/database-modules/grid/dataset_21.sql
+++ b/source/modules/src/data/sql/database-modules/grid/dataset_21.sql
@@ -1,2 +1,2 @@
-BEGIN; SELECT system.load_table('grid.receptors', '{data_folder}/common/grid/21/grid.receptors_20210924.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('grid.hexagons', '{data_folder}/common/grid/21/grid.hexagons_20210924.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('receptors', '{data_folder}/common/grid/21/grid.receptors_20210924.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('hexagons', '{data_folder}/common/grid/21/grid.hexagons_20210924.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/grid/dataset_22.sql
+++ b/source/modules/src/data/sql/database-modules/grid/dataset_22.sql
@@ -1,2 +1,2 @@
-BEGIN; SELECT system.load_table('grid.receptors', '{data_folder}/common/grid/22/grid.receptors_20220621.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('grid.hexagons', '{data_folder}/common/grid/22/grid.hexagons_20220621.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('receptors', '{data_folder}/common/grid/22/grid.receptors_20220621.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('hexagons', '{data_folder}/common/grid/22/grid.hexagons_20220621.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/grid/dataset_23.sql
+++ b/source/modules/src/data/sql/database-modules/grid/dataset_23.sql
@@ -1,2 +1,2 @@
-BEGIN; SELECT system.load_table('grid.receptors', '{data_folder}/common/grid/23/grid.receptors_20230511.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('grid.hexagons', '{data_folder}/common/grid/23/grid.hexagons_20230511.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('receptors', '{data_folder}/common/grid/23/grid.receptors_20230511.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('hexagons', '{data_folder}/common/grid/23/grid.hexagons_20230511.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/grid/dataset_24.sql
+++ b/source/modules/src/data/sql/database-modules/grid/dataset_24.sql
@@ -1,2 +1,2 @@
-BEGIN; SELECT system.load_table('grid.receptors', '{data_folder}/common/grid/24/grid.receptors_20240625.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('grid.hexagons', '{data_folder}/common/grid/24/grid.hexagons_20240625.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('receptors', '{data_folder}/common/grid/24/grid.receptors_20240625.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('hexagons', '{data_folder}/common/grid/24/grid.hexagons_20240625.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_areas/dataset_21.sql
+++ b/source/modules/src/data/sql/database-modules/nature_areas/dataset_21.sql
@@ -1,8 +1,8 @@
-BEGIN; SELECT system.load_table('nature.countries', '{data_folder}/common/nature_areas/21/nature.countries_20150721.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.authorities', '{data_folder}/common/nature_areas/21/nature.authorities_20191105.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('countries', '{data_folder}/common/nature_areas/21/nature.countries_20150721.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('authorities', '{data_folder}/common/nature_areas/21/nature.authorities_20191105.txt', FALSE); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.natura2000_areas', '{data_folder}/common/nature_areas/21/nature.natura2000_areas_20201113.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.natura2000_area_properties', '{data_folder}/common/nature_areas/21/nature.natura2000_area_properties_20200714.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_areas', '{data_folder}/common/nature_areas/21/nature.natura2000_areas_20201113.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_area_properties', '{data_folder}/common/nature_areas/21/nature.natura2000_area_properties_20200714.txt', FALSE); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.natura2000_directives', '{data_folder}/common/nature_areas/21/nature.natura2000_directives_20220328.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.natura2000_directive_areas', '{data_folder}/common/nature_areas/21/nature.natura2000_directive_areas_20220328.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_directives', '{data_folder}/common/nature_areas/21/nature.natura2000_directives_20220328.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_directive_areas', '{data_folder}/common/nature_areas/21/nature.natura2000_directive_areas_20220328.txt'); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_areas/dataset_22.sql
+++ b/source/modules/src/data/sql/database-modules/nature_areas/dataset_22.sql
@@ -1,8 +1,8 @@
-BEGIN; SELECT system.load_table('nature.countries', '{data_folder}/common/nature_areas/22/nature.countries_20150721.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.authorities', '{data_folder}/common/nature_areas/22/nature.authorities_20221115.txt'); COMMIT;
+BEGIN; SELECT system.load_table('countries', '{data_folder}/common/nature_areas/22/nature.countries_20150721.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('authorities', '{data_folder}/common/nature_areas/22/nature.authorities_20221115.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.natura2000_areas', '{data_folder}/common/nature_areas/22/nature.natura2000_areas_20220607.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.natura2000_area_properties', '{data_folder}/common/nature_areas/22/nature.natura2000_area_properties_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_areas', '{data_folder}/common/nature_areas/22/nature.natura2000_areas_20220607.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_area_properties', '{data_folder}/common/nature_areas/22/nature.natura2000_area_properties_20221216.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.natura2000_directives', '{data_folder}/common/nature_areas/22/nature.natura2000_directives_20220328.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.natura2000_directive_areas', '{data_folder}/common/nature_areas/22/nature.natura2000_directive_areas_20220607.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_directives', '{data_folder}/common/nature_areas/22/nature.natura2000_directives_20220328.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_directive_areas', '{data_folder}/common/nature_areas/22/nature.natura2000_directive_areas_20220607.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_areas/dataset_22_abroad.sql
+++ b/source/modules/src/data/sql/database-modules/nature_areas/dataset_22_abroad.sql
@@ -1,4 +1,4 @@
-BEGIN; SELECT system.load_table('nature.natura2000_areas', '{data_folder}/common/nature_areas/22/nature.natura2000_areas_abroad_20200616.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.natura2000_area_properties', '{data_folder}/common/nature_areas/22/nature.natura2000_area_properties_abroad_20200618.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_areas', '{data_folder}/common/nature_areas/22/nature.natura2000_areas_abroad_20200616.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_area_properties', '{data_folder}/common/nature_areas/22/nature.natura2000_area_properties_abroad_20200618.txt', FALSE); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.natura2000_directive_areas', '{data_folder}/common/nature_areas/22/nature.natura2000_directive_areas_abroad_20220328.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_directive_areas', '{data_folder}/common/nature_areas/22/nature.natura2000_directive_areas_abroad_20220328.txt'); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_areas/dataset_23.sql
+++ b/source/modules/src/data/sql/database-modules/nature_areas/dataset_23.sql
@@ -1,8 +1,8 @@
-BEGIN; SELECT system.load_table('nature.countries', '{data_folder}/common/nature_areas/23/nature.countries_20150721.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.authorities', '{data_folder}/common/nature_areas/23/nature.authorities_20221115.txt'); COMMIT;
+BEGIN; SELECT system.load_table('countries', '{data_folder}/common/nature_areas/23/nature.countries_20150721.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('authorities', '{data_folder}/common/nature_areas/23/nature.authorities_20221115.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.natura2000_areas', '{data_folder}/common/nature_areas/23/nature.natura2000_areas_20230503.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.natura2000_area_properties', '{data_folder}/common/nature_areas/23/nature.natura2000_area_properties_20230404.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_areas', '{data_folder}/common/nature_areas/23/nature.natura2000_areas_20230503.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_area_properties', '{data_folder}/common/nature_areas/23/nature.natura2000_area_properties_20230404.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.natura2000_directives', '{data_folder}/common/nature_areas/23/nature.natura2000_directives_20220328.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.natura2000_directive_areas', '{data_folder}/common/nature_areas/23/nature.natura2000_directive_areas_20230503.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_directives', '{data_folder}/common/nature_areas/23/nature.natura2000_directives_20220328.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_directive_areas', '{data_folder}/common/nature_areas/23/nature.natura2000_directive_areas_20230503.txt'); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_areas/dataset_23_abroad.sql
+++ b/source/modules/src/data/sql/database-modules/nature_areas/dataset_23_abroad.sql
@@ -1,4 +1,4 @@
-BEGIN; SELECT system.load_table('nature.natura2000_areas', '{data_folder}/common/nature_areas/23/nature.natura2000_areas_abroad_20230717.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.natura2000_area_properties', '{data_folder}/common/nature_areas/23/nature.natura2000_area_properties_abroad_20230717.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_areas', '{data_folder}/common/nature_areas/23/nature.natura2000_areas_abroad_20230717.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_area_properties', '{data_folder}/common/nature_areas/23/nature.natura2000_area_properties_abroad_20230717.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.natura2000_directive_areas', '{data_folder}/common/nature_areas/23/nature.natura2000_directive_areas_abroad_20230717.txt'); COMMIT;
+BEGIN; SELECT system.load_table('natura2000_directive_areas', '{data_folder}/common/nature_areas/23/nature.natura2000_directive_areas_abroad_20230717.txt'); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_habitats_and_species/dataset_21.sql
+++ b/source/modules/src/data/sql/database-modules/nature_habitats_and_species/dataset_21.sql
@@ -1,6 +1,6 @@
 {import_common 'database-modules/nature_habitats_and_species/supplied_21.sql'}
 
 -- Generated data
-BEGIN; SELECT system.load_table('nature.relevant_habitat_areas', '{data_folder}/common/nature_habitats_and_species/21/nature.relevant_habitat_areas_20210924.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitats', '{data_folder}/common/nature_habitats_and_species/21/nature.habitats_20210924.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.relevant_habitats', '{data_folder}/common/nature_habitats_and_species/21/nature.relevant_habitats_20210924.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('relevant_habitat_areas', '{data_folder}/common/nature_habitats_and_species/21/nature.relevant_habitat_areas_20210924.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitats', '{data_folder}/common/nature_habitats_and_species/21/nature.habitats_20210924.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('relevant_habitats', '{data_folder}/common/nature_habitats_and_species/21/nature.relevant_habitats_20210924.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_habitats_and_species/dataset_22.sql
+++ b/source/modules/src/data/sql/database-modules/nature_habitats_and_species/dataset_22.sql
@@ -1,6 +1,6 @@
 {import_common 'database-modules/nature_habitats_and_species/supplied_22.sql'}
 
 -- Generated data
-BEGIN; SELECT system.load_table('nature.relevant_habitat_areas', '{data_folder}/common/nature_habitats_and_species/22/nature.relevant_habitat_areas_20230104.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitats', '{data_folder}/common/nature_habitats_and_species/22/nature.habitats_20230104.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.relevant_habitats', '{data_folder}/common/nature_habitats_and_species/22/nature.relevant_habitats_20230104.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('relevant_habitat_areas', '{data_folder}/common/nature_habitats_and_species/22/nature.relevant_habitat_areas_20230104.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitats', '{data_folder}/common/nature_habitats_and_species/22/nature.habitats_20230104.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('relevant_habitats', '{data_folder}/common/nature_habitats_and_species/22/nature.relevant_habitats_20230104.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_habitats_and_species/dataset_23.sql
+++ b/source/modules/src/data/sql/database-modules/nature_habitats_and_species/dataset_23.sql
@@ -1,6 +1,6 @@
 {import_common 'database-modules/nature_habitats_and_species/supplied_23.sql'}
 
 -- Generated data
-BEGIN; SELECT system.load_table('nature.relevant_habitat_areas', '{data_folder}/common/nature_habitats_and_species/23/nature.relevant_habitat_areas_20230704.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitats', '{data_folder}/common/nature_habitats_and_species/23/nature.habitats_20230704.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.relevant_habitats', '{data_folder}/common/nature_habitats_and_species/23/nature.relevant_habitats_20230704.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('relevant_habitat_areas', '{data_folder}/common/nature_habitats_and_species/23/nature.relevant_habitat_areas_20230704.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitats', '{data_folder}/common/nature_habitats_and_species/23/nature.habitats_20230704.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('relevant_habitats', '{data_folder}/common/nature_habitats_and_species/23/nature.relevant_habitats_20230704.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_habitats_and_species/dataset_24.sql
+++ b/source/modules/src/data/sql/database-modules/nature_habitats_and_species/dataset_24.sql
@@ -1,6 +1,6 @@
 {import_common 'database-modules/nature_habitats_and_species/supplied_24.sql'}
 
 -- Generated data
-BEGIN; SELECT system.load_table('nature.relevant_habitat_areas', '{data_folder}/common/nature_habitats_and_species/24/nature.relevant_habitat_areas_20240625.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitats', '{data_folder}/common/nature_habitats_and_species/24/nature.habitats_20240625.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.relevant_habitats', '{data_folder}/common/nature_habitats_and_species/24/nature.relevant_habitats_20240625.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('relevant_habitat_areas', '{data_folder}/common/nature_habitats_and_species/24/nature.relevant_habitat_areas_20240625.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitats', '{data_folder}/common/nature_habitats_and_species/24/nature.habitats_20240625.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('relevant_habitats', '{data_folder}/common/nature_habitats_and_species/24/nature.relevant_habitats_20240625.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_habitats_and_species/supplied_21.sql
+++ b/source/modules/src/data/sql/database-modules/nature_habitats_and_species/supplied_21.sql
@@ -1,12 +1,12 @@
-BEGIN; SELECT system.load_table('nature.habitat_types', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_types_20200730.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_type_critical_levels', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_type_critical_levels_20200730.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_properties', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_properties_20200727.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_type_relations', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_type_relations_20200730.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_types', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_types_20200730.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_type_critical_levels', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_type_critical_levels_20200730.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_properties', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_properties_20200727.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_type_relations', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_type_relations_20200730.txt', FALSE); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.habitat_areas', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_areas_20210903.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_areas', '{data_folder}/common/nature_habitats_and_species/21/nature.habitat_areas_20210903.txt', FALSE); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.species', '{data_folder}/common/nature_habitats_and_species/21/nature.species_20200526.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.species_properties', '{data_folder}/common/nature_habitats_and_species/21/nature.species_properties_20200727.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.designated_species', '{data_folder}/common/nature_habitats_and_species/21/nature.designated_species_20200727.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('species', '{data_folder}/common/nature_habitats_and_species/21/nature.species_20200526.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('species_properties', '{data_folder}/common/nature_habitats_and_species/21/nature.species_properties_20200727.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('designated_species', '{data_folder}/common/nature_habitats_and_species/21/nature.designated_species_20200727.txt', FALSE); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.species_to_habitats', '{data_folder}/common/nature_habitats_and_species/21/nature.species_to_habitats_20200714.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('species_to_habitats', '{data_folder}/common/nature_habitats_and_species/21/nature.species_to_habitats_20200714.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_habitats_and_species/supplied_22.sql
+++ b/source/modules/src/data/sql/database-modules/nature_habitats_and_species/supplied_22.sql
@@ -1,12 +1,12 @@
-BEGIN; SELECT system.load_table('nature.habitat_types', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_types_20220607.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_type_critical_levels', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_type_critical_levels_20220607.txt', FALSE); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_properties', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_properties_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_type_relations', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_type_relations_20200730.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_types', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_types_20220607.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_type_critical_levels', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_type_critical_levels_20220607.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_properties', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_properties_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_type_relations', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_type_relations_20200730.txt', FALSE); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.habitat_areas', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_areas_20220603.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('habitat_areas', '{data_folder}/common/nature_habitats_and_species/22/nature.habitat_areas_20220603.txt', FALSE); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.species', '{data_folder}/common/nature_habitats_and_species/22/nature.species_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.species_properties', '{data_folder}/common/nature_habitats_and_species/22/nature.species_properties_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.designated_species', '{data_folder}/common/nature_habitats_and_species/22/nature.designated_species_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('species', '{data_folder}/common/nature_habitats_and_species/22/nature.species_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('species_properties', '{data_folder}/common/nature_habitats_and_species/22/nature.species_properties_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('designated_species', '{data_folder}/common/nature_habitats_and_species/22/nature.designated_species_20221216.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.species_to_habitats', '{data_folder}/common/nature_habitats_and_species/22/nature.species_to_habitats_20200714.txt', FALSE); COMMIT;
+BEGIN; SELECT system.load_table('species_to_habitats', '{data_folder}/common/nature_habitats_and_species/22/nature.species_to_habitats_20200714.txt', FALSE); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_habitats_and_species/supplied_23.sql
+++ b/source/modules/src/data/sql/database-modules/nature_habitats_and_species/supplied_23.sql
@@ -1,12 +1,12 @@
-BEGIN; SELECT system.load_table('nature.habitat_types', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_types_20230619.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_type_critical_levels', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_type_critical_levels_20230619.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_properties', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_properties_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_type_relations', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_type_relations_20230619.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_types', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_types_20230619.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_type_critical_levels', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_type_critical_levels_20230619.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_properties', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_properties_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_type_relations', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_type_relations_20230619.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.habitat_areas', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_areas_20230704.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_areas', '{data_folder}/common/nature_habitats_and_species/23/nature.habitat_areas_20230704.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.species', '{data_folder}/common/nature_habitats_and_species/23/nature.species_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.species_properties', '{data_folder}/common/nature_habitats_and_species/23/nature.species_properties_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.designated_species', '{data_folder}/common/nature_habitats_and_species/23/nature.designated_species_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('species', '{data_folder}/common/nature_habitats_and_species/23/nature.species_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('species_properties', '{data_folder}/common/nature_habitats_and_species/23/nature.species_properties_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('designated_species', '{data_folder}/common/nature_habitats_and_species/23/nature.designated_species_20221216.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.species_to_habitats', '{data_folder}/common/nature_habitats_and_species/23/nature.species_to_habitats_20230516.txt'); COMMIT;
+BEGIN; SELECT system.load_table('species_to_habitats', '{data_folder}/common/nature_habitats_and_species/23/nature.species_to_habitats_20230516.txt'); COMMIT;

--- a/source/modules/src/data/sql/database-modules/nature_habitats_and_species/supplied_24.sql
+++ b/source/modules/src/data/sql/database-modules/nature_habitats_and_species/supplied_24.sql
@@ -1,12 +1,12 @@
-BEGIN; SELECT system.load_table('nature.habitat_types', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_types_20230619.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_type_critical_levels', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_type_critical_levels_20231120.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_properties', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_properties_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.habitat_type_relations', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_type_relations_20230619.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_types', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_types_20230619.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_type_critical_levels', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_type_critical_levels_20231120.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_properties', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_properties_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_type_relations', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_type_relations_20230619.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.habitat_areas', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_areas_20240530.txt'); COMMIT;
+BEGIN; SELECT system.load_table('habitat_areas', '{data_folder}/common/nature_habitats_and_species/24/nature.habitat_areas_20240530.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.species', '{data_folder}/common/nature_habitats_and_species/24/nature.species_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.species_properties', '{data_folder}/common/nature_habitats_and_species/24/nature.species_properties_20221216.txt'); COMMIT;
-BEGIN; SELECT system.load_table('nature.designated_species', '{data_folder}/common/nature_habitats_and_species/24/nature.designated_species_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('species', '{data_folder}/common/nature_habitats_and_species/24/nature.species_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('species_properties', '{data_folder}/common/nature_habitats_and_species/24/nature.species_properties_20221216.txt'); COMMIT;
+BEGIN; SELECT system.load_table('designated_species', '{data_folder}/common/nature_habitats_and_species/24/nature.designated_species_20221216.txt'); COMMIT;
 
-BEGIN; SELECT system.load_table('nature.species_to_habitats', '{data_folder}/common/nature_habitats_and_species/24/nature.species_to_habitats_20230516.txt'); COMMIT;
+BEGIN; SELECT system.load_table('species_to_habitats', '{data_folder}/common/nature_habitats_and_species/24/nature.species_to_habitats_20230516.txt'); COMMIT;

--- a/source/modules/src/main/sql/database-modules/build_nature/views.sql
+++ b/source/modules/src/main/sql/database-modules/build_nature/views.sql
@@ -14,7 +14,7 @@
  * the habitat area should also be 'definitief', or at least 1 of the species in the habitat should be 'definitief'.
  * When the directive area is in the design ('ontwerp') status, then the habitats or species are not required to be 'definitief'.
  */
-CREATE OR REPLACE VIEW nature.build_relevant_habitat_areas_view AS
+CREATE OR REPLACE VIEW build_relevant_habitat_areas_view AS
 WITH natura2000_directive_area_properties AS (
 	SELECT
 		natura2000_directive_area_id,
@@ -24,9 +24,9 @@ WITH natura2000_directive_area_properties AS (
 		design_status AS natura2000_directive_area_design_status,
 		geometry
 
-		FROM nature.natura2000_directive_areas
-			INNER JOIN nature.natura2000_directives USING (natura2000_directive_id)
-			INNER JOIN nature.natura2000_area_properties USING (natura2000_area_id)
+		FROM natura2000_directive_areas
+			INNER JOIN natura2000_directives USING (natura2000_directive_id)
+			INNER JOIN natura2000_area_properties USING (natura2000_area_id)
 )
 SELECT * FROM
 	(SELECT
@@ -47,13 +47,13 @@ SELECT * FROM
 				natura2000_directive_area_properties.geometry AS natura2000_directive_area_geometry,
 				habitat_areas.geometry AS habitat_area_geometry
 
-				FROM nature.habitat_areas
-					INNER JOIN nature.habitat_types USING (habitat_type_id)
-					INNER JOIN nature.habitat_type_sensitivity_view USING (habitat_type_id)
+				FROM habitat_areas
+					INNER JOIN habitat_types USING (habitat_type_id)
+					INNER JOIN habitat_type_sensitivity_view USING (habitat_type_id)
 					INNER JOIN natura2000_directive_area_properties USING (assessment_area_id)
-					INNER JOIN nature.habitat_type_relations USING (habitat_type_id)
-					LEFT JOIN nature.habitat_properties USING (goal_habitat_type_id, assessment_area_id)
-					LEFT JOIN nature.designated_habitats_view USING (habitat_type_id, assessment_area_id)
+					INNER JOIN habitat_type_relations USING (habitat_type_id)
+					LEFT JOIN habitat_properties USING (goal_habitat_type_id, assessment_area_id)
+					LEFT JOIN designated_habitats_view USING (habitat_type_id, assessment_area_id)
 
 				WHERE
 					sensitive IS TRUE
@@ -75,12 +75,12 @@ SELECT * FROM
 				natura2000_directive_area_properties.geometry AS natura2000_directive_area_geometry,
 				habitat_areas.geometry AS habitat_area_geometry
 
-				FROM nature.habitat_areas
-					INNER JOIN nature.habitat_type_sensitivity_view USING (habitat_type_id)
+				FROM habitat_areas
+					INNER JOIN habitat_type_sensitivity_view USING (habitat_type_id)
 					INNER JOIN natura2000_directive_area_properties USING (assessment_area_id)
-					INNER JOIN nature.designated_species_to_habitats_view USING (assessment_area_id, habitat_type_id)
-					INNER JOIN nature.species USING (species_id)
-					INNER JOIN nature.species_properties USING (species_id, assessment_area_id)
+					INNER JOIN designated_species_to_habitats_view USING (assessment_area_id, habitat_type_id)
+					INNER JOIN species USING (species_id)
+					INNER JOIN species_properties USING (species_id, assessment_area_id)
 
 				WHERE
 					sensitive IS TRUE
@@ -105,14 +105,14 @@ SELECT * FROM
  *
  * When determining the average coverage for a habitat, the surface of the individual habitat areas is used as weight.
  */
-CREATE OR REPLACE VIEW nature.build_habitats_view AS
+CREATE OR REPLACE VIEW build_habitats_view AS
 SELECT
 	assessment_area_id,
 	habitat_type_id,
 	system.weighted_avg(coverage::numeric, ST_Area(habitat_areas.geometry)::numeric)::fraction AS habitat_coverage,
 	ST_CollectionExtract(ST_Multi(ST_Union(habitat_areas.geometry)), 3) AS geometry
 
-	FROM nature.habitat_areas
+	FROM habitat_areas
 
 	GROUP BY assessment_area_id, habitat_type_id
 ;
@@ -127,15 +127,15 @@ SELECT
  * When the habitat area is partly relevant, the whole area of the habitat is used as the weight.
  * This prevents the assumption that the coverage is equally spread over the entire habitat area.
  */
-CREATE OR REPLACE VIEW nature.build_relevant_habitats_view AS
+CREATE OR REPLACE VIEW build_relevant_habitats_view AS
 SELECT
 	assessment_area_id,
 	habitat_type_id,
 	system.weighted_avg(habitat_areas.coverage::numeric, ST_Area(habitat_areas.geometry)::numeric)::fraction AS habitat_coverage,
 	ST_CollectionExtract(ST_Multi(ST_Union(relevant_habitat_areas.geometry)), 3) AS geometry
 
-	FROM nature.relevant_habitat_areas
-		INNER JOIN nature.habitat_areas USING (assessment_area_id, habitat_area_id, habitat_type_id)
+	FROM relevant_habitat_areas
+		INNER JOIN habitat_areas USING (assessment_area_id, habitat_area_id, habitat_type_id)
 
 	GROUP BY assessment_area_id, habitat_type_id
 ;

--- a/source/modules/src/main/sql/database-modules/grid/00-schema.sql
+++ b/source/modules/src/main/sql/database-modules/grid/00-schema.sql
@@ -1,6 +1,0 @@
-/*
- * grid
- * ----
- * The grid schema contains all receptor and hexagon related tables.
- */
-CREATE SCHEMA IF NOT EXISTS grid;

--- a/source/modules/src/main/sql/database-modules/grid/01-tables.sql
+++ b/source/modules/src/main/sql/database-modules/grid/01-tables.sql
@@ -4,14 +4,14 @@
  * Table containing the receptors (standard calculation points).
  * Receptors represent the center point of the accompanying hexagons.
  */
-CREATE TABLE grid.receptors (
+CREATE TABLE receptors (
 	receptor_id integer NOT NULL,
 	geometry geometry(Point),
 
 	CONSTRAINT receptors_pkey PRIMARY KEY (receptor_id)
 );
 
-CREATE INDEX idx_receptors_geometry_gist ON grid.receptors USING GIST (geometry);
+CREATE INDEX idx_receptors_geometry_gist ON receptors USING GIST (geometry);
 
 
 /*
@@ -23,14 +23,14 @@ CREATE INDEX idx_receptors_geometry_gist ON grid.receptors USING GIST (geometry)
  * For UK, the surface of a hexagon at zoom level 1 matches 4 hectares.
  * At higher zoom levels the hexagons are aggregations.
  */
-CREATE TABLE grid.hexagons (
+CREATE TABLE hexagons (
 	receptor_id integer NOT NULL,
 	zoom_level posint NOT NULL,
 	geometry geometry(Polygon),
 
 	CONSTRAINT hexagons_pkey PRIMARY KEY (receptor_id, zoom_level),
-	CONSTRAINT hexagons_fkey_receptors FOREIGN KEY (receptor_id) REFERENCES grid.receptors
+	CONSTRAINT hexagons_fkey_receptors FOREIGN KEY (receptor_id) REFERENCES receptors
 );
 
-CREATE INDEX idx_hexagons_geometry_gist ON grid.hexagons USING GIST (geometry);
-CREATE INDEX idx_hexagons_zoom_level ON grid.hexagons (zoom_level);
+CREATE INDEX idx_hexagons_geometry_gist ON hexagons USING GIST (geometry);
+CREATE INDEX idx_hexagons_zoom_level ON hexagons (zoom_level);

--- a/source/modules/src/main/sql/database-modules/nature_areas/00-schema.sql
+++ b/source/modules/src/main/sql/database-modules/nature_areas/00-schema.sql
@@ -1,6 +1,0 @@
-/*
- * nature
- * ------
- * The nature schema contains all nature related tables.
- */
-CREATE SCHEMA IF NOT EXISTS nature;

--- a/source/modules/src/main/sql/database-modules/nature_areas/01-types.sql
+++ b/source/modules/src/main/sql/database-modules/nature_areas/01-types.sql
@@ -4,7 +4,7 @@
  * The typ of an authority.
  * Be aware that the order of this enum also dictates how the entries in the authorities table are sorted in the UI (for example in a dropdown box).
  */
-CREATE TYPE nature.authority_type AS ENUM
+CREATE TYPE authority_type AS ENUM
 	('unknown', 'province', 'ministry', 'foreign');
 
 /*
@@ -13,7 +13,7 @@ CREATE TYPE nature.authority_type AS ENUM
  * The type of the design status (status van een doelstelling) of a habitat type or species.
  *
  */
-CREATE TYPE nature.design_status_type AS ENUM
+CREATE TYPE design_status_type AS ENUM
 	('aanmelding', 'ontwerp', 'definitief', 'irrelevant');
 
 
@@ -22,5 +22,5 @@ CREATE TYPE nature.design_status_type AS ENUM
  * --------------------
  * The type of an assesment area.
  */
-CREATE TYPE nature.assessment_area_type AS ENUM
+CREATE TYPE assessment_area_type AS ENUM
 	('natura2000_area', 'natura2000_directive_area');

--- a/source/modules/src/main/sql/database-modules/nature_areas/02-tables.sql
+++ b/source/modules/src/main/sql/database-modules/nature_areas/02-tables.sql
@@ -4,7 +4,7 @@
  * Table containing countries.
  * Contains a code (for use URL and such) and a more extensive name/description.
  */
-CREATE TABLE nature.countries (
+CREATE TABLE countries (
 	country_id integer NOT NULL,
 	code text NOT NULL,
 	name text NOT NULL,
@@ -20,16 +20,16 @@ CREATE TABLE nature.countries (
  * Table containing competent authorities.
  * Contains a code (for use URL and such), a more extensive name/description and an authority type.
  */
-CREATE TABLE nature.authorities (
+CREATE TABLE authorities (
 	authority_id integer NOT NULL,
 	country_id integer NOT NULL,
 	code text NOT NULL,
 	name text NOT NULL,
-	type nature.authority_type NOT NULL,
+	type authority_type NOT NULL,
 
 	CONSTRAINT authorities_pkey PRIMARY KEY (authority_id),
 	CONSTRAINT authorities_code_unique UNIQUE (code),
-	CONSTRAINT authorities_fkey_countries FOREIGN KEY (country_id) REFERENCES nature.countries
+	CONSTRAINT authorities_fkey_countries FOREIGN KEY (country_id) REFERENCES countries
 );
 
 
@@ -42,22 +42,22 @@ CREATE TABLE nature.authorities (
  * 1..10000 = N2000 areas (in natura2000_areas) (1000+ = abroad)
  * 10001..20000 = N2000 directive areas (in natura2000_directive_areas)
  */
-CREATE TABLE nature.assessment_areas
+CREATE TABLE assessment_areas
 (
 	assessment_area_id integer NOT NULL,
-	type nature.assessment_area_type NOT NULL,
+	type assessment_area_type NOT NULL,
 	name text NOT NULL,
 	code text NOT NULL,
 	authority_id integer NOT NULL,
 	geometry geometry(MultiPolygon),
 
 	CONSTRAINT assessment_areas_pkey PRIMARY KEY (assessment_area_id),
-	CONSTRAINT assessment_areas_fkey_authorities FOREIGN KEY (authority_id) REFERENCES nature.authorities,
+	CONSTRAINT assessment_areas_fkey_authorities FOREIGN KEY (authority_id) REFERENCES authorities,
 	CONSTRAINT assessment_areas_code_unique UNIQUE (code)
 );
 
-CREATE INDEX idx_assessment_areas_geometry_gist ON nature.assessment_areas USING GIST (geometry);
-CREATE INDEX idx_assessment_areas_name ON nature.assessment_areas (name);
+CREATE INDEX idx_assessment_areas_geometry_gist ON assessment_areas USING GIST (geometry);
+CREATE INDEX idx_assessment_areas_name ON assessment_areas (name);
 
 
 /*
@@ -69,17 +69,17 @@ CREATE INDEX idx_assessment_areas_name ON nature.assessment_areas (name);
  * In the case of NL: the natura2000_area_id matches the official Natura 2000 area numbers as used in the netherlands.
  * In the case of UK: this table contains the nature sites.
  */
-CREATE TABLE nature.natura2000_areas
+CREATE TABLE natura2000_areas
 (
 	natura2000_area_id integer NOT NULL,
 
 	CONSTRAINT natura2000_areas_pkey PRIMARY KEY (natura2000_area_id)
 
-) INHERITS (nature.assessment_areas);
+) INHERITS (assessment_areas);
 
-CREATE UNIQUE INDEX idx_natura2000_areas_assessment_area_id ON nature.natura2000_areas (assessment_area_id);
-CREATE INDEX idx_natura2000_areas_geometry_gist ON nature.natura2000_areas USING GIST (geometry);
-CREATE INDEX idx_natura2000_areas_name ON nature.natura2000_areas (name);
+CREATE UNIQUE INDEX idx_natura2000_areas_assessment_area_id ON natura2000_areas (assessment_area_id);
+CREATE INDEX idx_natura2000_areas_geometry_gist ON natura2000_areas USING GIST (geometry);
+CREATE INDEX idx_natura2000_areas_name ON natura2000_areas (name);
 
 
 /*
@@ -90,13 +90,13 @@ CREATE INDEX idx_natura2000_areas_name ON nature.natura2000_areas (name);
  * @column registered_surface is the surface as it is registered in the designation decision (aanwijsbesluit)
  * @column design_status specifies the 'vaststellings-status' for the N2000 area.
  */
-CREATE TABLE nature.natura2000_area_properties (
+CREATE TABLE natura2000_area_properties (
 	natura2000_area_id integer NOT NULL,
 	registered_surface bigint NOT NULL,
-	design_status nature.design_status_type NOT NULL,
+	design_status design_status_type NOT NULL,
 
 	CONSTRAINT natura2000_area_properties_pkey PRIMARY KEY (natura2000_area_id),
-	CONSTRAINT natura2000_area_properties_fkey_natura2000_areas FOREIGN KEY (natura2000_area_id) REFERENCES nature.natura2000_areas
+	CONSTRAINT natura2000_area_properties_fkey_natura2000_areas FOREIGN KEY (natura2000_area_id) REFERENCES natura2000_areas
 );
 
 
@@ -108,7 +108,7 @@ CREATE TABLE nature.natura2000_area_properties (
  * Each directive specifies if it is a habitat directive and/or a species directive.
  * This influences in what way an area will be incorporated when it comes to relevant habitat areas.
  */
-CREATE TABLE nature.natura2000_directives
+CREATE TABLE natura2000_directives
 (
 	natura2000_directive_id integer NOT NULL,
 	directive_code text NOT NULL,
@@ -126,7 +126,7 @@ CREATE TABLE nature.natura2000_directives
  * --------------------------
  * Table containing the sections of the nature sites (natura2000 areas) with their own directive(s).
  */
-CREATE TABLE nature.natura2000_directive_areas
+CREATE TABLE natura2000_directive_areas
 (
 	natura2000_directive_area_id integer NOT NULL,
 	natura2000_area_id integer NOT NULL,
@@ -134,10 +134,10 @@ CREATE TABLE nature.natura2000_directive_areas
 	design_status_description text NOT NULL,
 
 	CONSTRAINT natura2000_directive_areas_pkey PRIMARY KEY (natura2000_directive_area_id),
-	CONSTRAINT natura2000_directive_areas_fkey_natura2000_areas FOREIGN KEY (natura2000_area_id) REFERENCES nature.natura2000_areas,
-	CONSTRAINT natura2000_directive_areas_fkey_natura2000_directives FOREIGN KEY (natura2000_directive_id) REFERENCES nature.natura2000_directives
-) INHERITS (nature.assessment_areas);
+	CONSTRAINT natura2000_directive_areas_fkey_natura2000_areas FOREIGN KEY (natura2000_area_id) REFERENCES natura2000_areas,
+	CONSTRAINT natura2000_directive_areas_fkey_natura2000_directives FOREIGN KEY (natura2000_directive_id) REFERENCES natura2000_directives
+) INHERITS (assessment_areas);
 
-CREATE UNIQUE INDEX idx_natura2000_directive_areas_assessment_area_id ON nature.natura2000_directive_areas (assessment_area_id);
-CREATE INDEX idx_natura2000_directive_areas_geometry_gist ON nature.natura2000_directive_areas USING GIST (geometry);
-CREATE INDEX idx_natura2000_directive_areas_name ON nature.natura2000_directive_areas (name);
+CREATE UNIQUE INDEX idx_natura2000_directive_areas_assessment_area_id ON natura2000_directive_areas (assessment_area_id);
+CREATE INDEX idx_natura2000_directive_areas_geometry_gist ON natura2000_directive_areas USING GIST (geometry);
+CREATE INDEX idx_natura2000_directive_areas_name ON natura2000_directive_areas (name);

--- a/source/modules/src/main/sql/database-modules/nature_areas/04-views.sql
+++ b/source/modules/src/main/sql/database-modules/nature_areas/04-views.sql
@@ -6,7 +6,7 @@
  * This information is combinated into a N2000 area property.
  * As a result, this view only works for entire N2000 areas.
  */
-CREATE OR REPLACE VIEW nature.assessment_area_directive_view AS
+CREATE OR REPLACE VIEW assessment_area_directive_view AS
 SELECT
 	natura2000_areas.assessment_area_id,
 	natura2000_directive_areas.natura2000_area_id,
@@ -14,13 +14,13 @@ SELECT
 	array_to_string(array_agg(DISTINCT directive_name ORDER BY directive_name), ', ') AS directive,
 	array_to_string(array_agg(DISTINCT natura2000_directive_areas.design_status_description), ', ') AS design_status_description
 
-	FROM nature.natura2000_directive_areas
+	FROM natura2000_directive_areas
 		INNER JOIN (
 			SELECT natura2000_directive_area_id, UNNEST(string_to_array(directive_code, ', ')) AS directive_code, UNNEST(string_to_array(directive_name, ', ')) AS directive_name
-				FROM nature.natura2000_directive_areas
-					INNER JOIN nature.natura2000_directives USING (natura2000_directive_id)
+				FROM natura2000_directive_areas
+					INNER JOIN natura2000_directives USING (natura2000_directive_id)
 			) AS directives USING (natura2000_directive_area_id)
-		INNER JOIN nature.natura2000_areas USING (natura2000_area_id)
+		INNER JOIN natura2000_areas USING (natura2000_area_id)
 
 	GROUP BY natura2000_areas.assessment_area_id, natura2000_area_id
 ;
@@ -32,7 +32,7 @@ SELECT
  * View returning general information about the N2000 areas.
  * Use 'assessment_area_id', 'natura2000_area_id' or ST_Intersects(ST_SetSRID(ST_Point(218928, 486793), ae_get_srid()), geometry) in the where-clause.
  */
-CREATE OR REPLACE VIEW nature.natura2000_area_info_view AS
+CREATE OR REPLACE VIEW natura2000_area_info_view AS
 SELECT
 	assessment_area_id,
 	natura2000_area_id,
@@ -45,10 +45,10 @@ SELECT
 	Box2D(natura2000_areas.geometry) AS boundingbox,
 	natura2000_areas.geometry
 
-	FROM nature.natura2000_areas
-		INNER JOIN nature.assessment_area_directive_view USING (assessment_area_id, natura2000_area_id)
-		INNER JOIN nature.authorities USING (authority_id)
-		LEFT JOIN nature.natura2000_area_properties USING (natura2000_area_id)
+	FROM natura2000_areas
+		INNER JOIN assessment_area_directive_view USING (assessment_area_id, natura2000_area_id)
+		INNER JOIN authorities USING (authority_id)
+		LEFT JOIN natura2000_area_properties USING (natura2000_area_id)
 ;
 
 
@@ -58,7 +58,7 @@ SELECT
  * WMS view returning the natura2000 directive areas, including name.
  * Selectie van natura2000_directive_areas (inclusief naam).
  */
-CREATE OR REPLACE VIEW nature.wms_nature_areas_view AS
+CREATE OR REPLACE VIEW wms_nature_areas_view AS
 SELECT
 	natura2000_areas.assessment_area_id,
 	country_id,
@@ -68,8 +68,8 @@ SELECT
 	natura2000_areas.name,
 	natura2000_directive_areas.geometry
 
-	FROM nature.natura2000_directive_areas
-		INNER JOIN nature.natura2000_directives USING (natura2000_directive_id)
-		INNER JOIN nature.authorities USING (authority_id)
-		INNER JOIN nature.natura2000_areas USING (natura2000_area_id)
+	FROM natura2000_directive_areas
+		INNER JOIN natura2000_directives USING (natura2000_directive_id)
+		INNER JOIN authorities USING (authority_id)
+		INNER JOIN natura2000_areas USING (natura2000_area_id)
 ;

--- a/source/modules/src/main/sql/database-modules/nature_habitats_and_species/00-schema.sql
+++ b/source/modules/src/main/sql/database-modules/nature_habitats_and_species/00-schema.sql
@@ -1,6 +1,0 @@
-/*
- * nature
- * ------
- * The nature schema contains all nature related tables.
- */
-CREATE SCHEMA IF NOT EXISTS nature;

--- a/source/modules/src/main/sql/database-modules/nature_habitats_and_species/01-types.sql
+++ b/source/modules/src/main/sql/database-modules/nature_habitats_and_species/01-types.sql
@@ -15,7 +15,7 @@
  * <       decrease is allowed
  * = (<)   decrease in favor of another species is allowed
  */
-CREATE TYPE nature.habitat_goal_type AS ENUM
+CREATE TYPE habitat_goal_type AS ENUM
 	('specified', 'none', 'level', 'increase', 'level_increase', 'decrease', 'level_decrease', 'increase_may_decrease');
 
 /*
@@ -23,7 +23,7 @@ CREATE TYPE nature.habitat_goal_type AS ENUM
  * ------------
  * The type of a (animal) species which are present in a habitat.
  */
-CREATE TYPE nature.species_type AS ENUM
+CREATE TYPE species_type AS ENUM
 	('habitat_species', 'breeding_bird_species', 'non_breeding_bird_species');
 
 /*
@@ -31,7 +31,7 @@ CREATE TYPE nature.species_type AS ENUM
  * -----------------------------
  * The type of a critical deposition area.
  */
-CREATE TYPE nature.critical_deposition_area_type AS ENUM
+CREATE TYPE critical_deposition_area_type AS ENUM
 	('relevant_habitat', 'habitat');
 
 /*
@@ -39,5 +39,5 @@ CREATE TYPE nature.critical_deposition_area_type AS ENUM
  * ----------------------------------
  * Enum type for critical load (KDW, Kritische Depositie Waarde) classifications.
  */
-CREATE TYPE nature.critical_deposition_classification AS ENUM
+CREATE TYPE critical_deposition_classification AS ENUM
 	('high_sensitivity', 'normal_sensitivity', 'low_sensitivity');

--- a/source/modules/src/main/sql/database-modules/nature_habitats_and_species/02-tables.sql
+++ b/source/modules/src/main/sql/database-modules/nature_habitats_and_species/02-tables.sql
@@ -3,7 +3,7 @@
  * -------------
  * Table containing the habitat types, identified by the name column and with an additional description.
  */
-CREATE TABLE nature.habitat_types
+CREATE TABLE habitat_types
 (
 	habitat_type_id integer NOT NULL,
 	name text NOT NULL,
@@ -12,7 +12,7 @@ CREATE TABLE nature.habitat_types
 	CONSTRAINT habitat_types_pkey PRIMARY KEY (habitat_type_id)
 );
 
-CREATE UNIQUE INDEX idx_habitat_types_name ON nature.habitat_types (name);
+CREATE UNIQUE INDEX idx_habitat_types_name ON habitat_types (name);
 
 
 /*
@@ -21,7 +21,7 @@ CREATE UNIQUE INDEX idx_habitat_types_name ON nature.habitat_types (name);
  * Table containing the critical levels for the habitat types per substance and emission result type.
  * NOTE: For critical nitrogen deposition (KDW) a value has to be used for substance ID 1711 and result type "deposition".
  */
-CREATE TABLE nature.habitat_type_critical_levels (
+CREATE TABLE habitat_type_critical_levels (
 	habitat_type_id integer NOT NULL,
 	substance_id smallint NOT NULL,
 	result_type emission_result_type NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE nature.habitat_type_critical_levels (
 	sensitive boolean NOT NULL DEFAULT FALSE,
 
 	CONSTRAINT habitat_type_critical_levels_pkey PRIMARY KEY (habitat_type_id, substance_id, result_type),
-	CONSTRAINT habitat_type_critical_levels_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES nature.habitat_types
+	CONSTRAINT habitat_type_critical_levels_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES habitat_types
 );
 
 
@@ -41,15 +41,15 @@ CREATE TABLE nature.habitat_type_critical_levels (
  * @column extent_goal The goal for extent/surface (doelstelling oppervlakte).
  * @column design_status The status of this habitat type (vaststellings status).
  */
-CREATE TABLE nature.habitat_properties (
+CREATE TABLE habitat_properties (
 	goal_habitat_type_id integer NOT NULL,
 	assessment_area_id integer NOT NULL,
-	quality_goal nature.habitat_goal_type NOT NULL,
-	extent_goal nature.habitat_goal_type NOT NULL,
-	design_status nature.design_status_type NOT NULL CHECK (design_status <> 'irrelevant'),
+	quality_goal habitat_goal_type NOT NULL,
+	extent_goal habitat_goal_type NOT NULL,
+	design_status design_status_type NOT NULL CHECK (design_status <> 'irrelevant'),
 
 	CONSTRAINT habitat_properties_pkey PRIMARY KEY (goal_habitat_type_id, assessment_area_id),
-	CONSTRAINT habitat_properties_fkey_habitat_types FOREIGN KEY (goal_habitat_type_id) REFERENCES nature.habitat_types (habitat_type_id)
+	CONSTRAINT habitat_properties_fkey_habitat_types FOREIGN KEY (goal_habitat_type_id) REFERENCES habitat_types (habitat_type_id)
 );
 
 
@@ -62,14 +62,14 @@ CREATE TABLE nature.habitat_properties (
  * This parent-child relation is kept in this table.
  * A habitat type can only have 1 goal habitat type. Most habitat types have themselves as the goal habitat type.
  */
-CREATE TABLE nature.habitat_type_relations
+CREATE TABLE habitat_type_relations
 (
 	habitat_type_id integer NOT NULL UNIQUE,
 	goal_habitat_type_id integer NOT NULL,
 
 	CONSTRAINT habitat_type_relations_pkey PRIMARY KEY (habitat_type_id, goal_habitat_type_id),
-	CONSTRAINT habitat_type_relations_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES nature.habitat_types,
-	CONSTRAINT habitat_type_relations_fkey_goal_habitat_types FOREIGN KEY (goal_habitat_type_id) REFERENCES nature.habitat_types (habitat_type_id)
+	CONSTRAINT habitat_type_relations_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES habitat_types,
+	CONSTRAINT habitat_type_relations_fkey_goal_habitat_types FOREIGN KEY (goal_habitat_type_id) REFERENCES habitat_types (habitat_type_id)
 );
 
 
@@ -80,7 +80,7 @@ CREATE TABLE nature.habitat_type_relations
  *
  * @column coverage The coverage of the habitat over the area (Dekkingsgraad). This factor is used to determine the cartographic surface.
  */
-CREATE TABLE nature.habitat_areas
+CREATE TABLE habitat_areas
 (
 	assessment_area_id integer NOT NULL,
 	habitat_area_id integer NOT NULL,
@@ -89,12 +89,12 @@ CREATE TABLE nature.habitat_areas
 	geometry geometry(MultiPolygon),
 
 	CONSTRAINT habitat_areas_pkey PRIMARY KEY (habitat_area_id),
-	CONSTRAINT habitat_areas_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES nature.habitat_types
+	CONSTRAINT habitat_areas_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES habitat_types
 );
 
-CREATE INDEX idx_habitat_areas_geometry_gist ON nature.habitat_areas USING GIST (geometry);
-CREATE INDEX idx_habitat_areas_assessment_area_id ON nature.habitat_areas (assessment_area_id);
-CREATE INDEX idx_habitat_areas_habitat_type_id ON nature.habitat_areas (habitat_type_id);
+CREATE INDEX idx_habitat_areas_geometry_gist ON habitat_areas USING GIST (geometry);
+CREATE INDEX idx_habitat_areas_assessment_area_id ON habitat_areas (assessment_area_id);
+CREATE INDEX idx_habitat_areas_habitat_type_id ON habitat_areas (habitat_type_id);
 
 
 /*
@@ -107,7 +107,7 @@ CREATE INDEX idx_habitat_areas_habitat_type_id ON nature.habitat_areas (habitat_
  * 
  * @column coverage Coverage of the whole habitat area, equal to {@link habitat_areas}.
  */
-CREATE TABLE nature.relevant_habitat_areas
+CREATE TABLE relevant_habitat_areas
 (
 	assessment_area_id integer NOT NULL,
 	habitat_area_id integer NOT NULL,
@@ -116,12 +116,12 @@ CREATE TABLE nature.relevant_habitat_areas
 	geometry geometry(MultiPolygon),
 
 	CONSTRAINT relevant_habitat_areas_pkey PRIMARY KEY (habitat_area_id),
-	CONSTRAINT relevant_habitat_areas_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES nature.habitat_types
+	CONSTRAINT relevant_habitat_areas_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES habitat_types
 );
 
-CREATE INDEX idx_relevant_habitat_areas_geometry_gist ON nature.relevant_habitat_areas USING GIST (geometry);
-CREATE INDEX idx_relevant_habitat_areas_assessment_area_id ON nature.relevant_habitat_areas (assessment_area_id);
-CREATE INDEX idx_relevant_habitat_areas_habitat_type_id ON nature.relevant_habitat_areas (habitat_type_id);
+CREATE INDEX idx_relevant_habitat_areas_geometry_gist ON relevant_habitat_areas USING GIST (geometry);
+CREATE INDEX idx_relevant_habitat_areas_assessment_area_id ON relevant_habitat_areas (assessment_area_id);
+CREATE INDEX idx_relevant_habitat_areas_habitat_type_id ON relevant_habitat_areas (habitat_type_id);
 
 
 /*
@@ -133,7 +133,7 @@ CREATE INDEX idx_relevant_habitat_areas_habitat_type_id ON nature.relevant_habit
  * @column habitat_coverage Average coverage for this habitat. Calculated based on the average of the individual habitat areas, 
  * weighted by surface of each area.
  */
-CREATE TABLE nature.habitats
+CREATE TABLE habitats
 (
 	assessment_area_id integer NOT NULL,
 	habitat_type_id integer NOT NULL,
@@ -141,11 +141,11 @@ CREATE TABLE nature.habitats
 	geometry geometry(MultiPolygon),
 
 	CONSTRAINT habitats_pkey PRIMARY KEY (assessment_area_id, habitat_type_id),
-	CONSTRAINT habitats_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES nature.habitat_types
+	CONSTRAINT habitats_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES habitat_types
 );
 
-CREATE INDEX idx_habitats_geometry_gist ON nature.habitats USING GIST (geometry);
-CREATE INDEX idx_habitats_habitat_type_id ON nature.habitats (habitat_type_id);
+CREATE INDEX idx_habitats_geometry_gist ON habitats USING GIST (geometry);
+CREATE INDEX idx_habitats_habitat_type_id ON habitats (habitat_type_id);
 
 
 /*
@@ -156,7 +156,7 @@ CREATE INDEX idx_habitats_habitat_type_id ON nature.habitats (habitat_type_id);
  * @column habitat_coverage Average coverage for this habitat. Calculated based on the average of the individual habitat areas, 
  * weighted by surface of each area. For partially relevant habitat areas, the full surface of the area is used as the weight.
  */
-CREATE TABLE nature.relevant_habitats
+CREATE TABLE relevant_habitats
 (
 	assessment_area_id integer NOT NULL,
 	habitat_type_id integer NOT NULL,
@@ -164,11 +164,11 @@ CREATE TABLE nature.relevant_habitats
 	geometry geometry(MultiPolygon),
 
 	CONSTRAINT relevant_habitats_pkey PRIMARY KEY (assessment_area_id, habitat_type_id),
-	CONSTRAINT relevant_habitats_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES nature.habitat_types
+	CONSTRAINT relevant_habitats_fkey_habitat_types FOREIGN KEY (habitat_type_id) REFERENCES habitat_types
 );
 
-CREATE INDEX idx_relevant_habitats_geometry_gist ON nature.relevant_habitats USING GIST (geometry);
-CREATE INDEX idx_relevant_habitats_habitat_type_id ON nature.relevant_habitats (habitat_type_id);
+CREATE INDEX idx_relevant_habitats_geometry_gist ON relevant_habitats USING GIST (geometry);
+CREATE INDEX idx_relevant_habitats_habitat_type_id ON relevant_habitats (habitat_type_id);
 
 
 /*
@@ -178,17 +178,17 @@ CREATE INDEX idx_relevant_habitats_habitat_type_id ON nature.relevant_habitats (
  * This can be habitat species, breeding bird species and non breeding bird species.
  * A bird species can be present as both breeding and non-breeding in this table, as for some areas it is considered breeding while for others it is not.
  */
-CREATE TABLE nature.species
+CREATE TABLE species
 (
 	species_id integer NOT NULL,
 	name text NOT NULL,
 	description text NOT NULL,
-	species_type nature.species_type NOT NULL,
+	species_type species_type NOT NULL,
 
 	CONSTRAINT species_pkey PRIMARY KEY (species_id)
 );
 
-CREATE UNIQUE INDEX idx_species_name ON nature.species (name, species_type);
+CREATE UNIQUE INDEX idx_species_name ON species (name, species_type);
 
 
 /*
@@ -200,18 +200,18 @@ CREATE UNIQUE INDEX idx_species_name ON nature.species (name, species_type);
  * The population goal for non breeding bird species is supplied as text. The population_goal must be 'specified' in that case.
  * In all other cases and goal types the goal shouldn't be 'specified'.
  */
-CREATE TABLE nature.species_properties (
+CREATE TABLE species_properties (
 	species_id integer NOT NULL,
 	assessment_area_id integer NOT NULL,
-	quality_goal nature.habitat_goal_type NOT NULL CHECK (quality_goal <> 'specified'),
-	extent_goal nature.habitat_goal_type NOT NULL CHECK (extent_goal <> 'specified'),
-	population_goal nature.habitat_goal_type NOT NULL
+	quality_goal habitat_goal_type NOT NULL CHECK (quality_goal <> 'specified'),
+	extent_goal habitat_goal_type NOT NULL CHECK (extent_goal <> 'specified'),
+	population_goal habitat_goal_type NOT NULL
 		CHECK ((population_goal <> 'specified' AND population_goal_description IS NULL) OR (population_goal = 'specified' AND population_goal_description IS NOT NULL)),
 	population_goal_description text, -- TODO: need some refactoring
-	design_status nature.design_status_type NOT NULL CHECK (design_status <> 'irrelevant'),
+	design_status design_status_type NOT NULL CHECK (design_status <> 'irrelevant'),
 
 	CONSTRAINT species_properties_pkey PRIMARY KEY (species_id, assessment_area_id),
-	CONSTRAINT species_properties_fkey_species FOREIGN KEY (species_id) REFERENCES nature.species
+	CONSTRAINT species_properties_fkey_species FOREIGN KEY (species_id) REFERENCES species
 );
 
 
@@ -220,14 +220,14 @@ CREATE TABLE nature.species_properties (
  * ------------------
  * Table containing designated species per assessment areas.
  */
-CREATE TABLE nature.designated_species
+CREATE TABLE designated_species
 (
 	species_id integer NOT NULL,
 	assessment_area_id integer NOT NULL,
 
 	CONSTRAINT designated_species_pkey PRIMARY KEY (species_id, assessment_area_id),
-	CONSTRAINT designated_species_fkey_assessment_areas FOREIGN KEY (assessment_area_id) REFERENCES nature.natura2000_areas (assessment_area_id), -- Currently limited to N2000. Can't reference base table 'assessment_areas'.
-	CONSTRAINT designated_species_fkey_species FOREIGN KEY (species_id) REFERENCES nature.species
+	CONSTRAINT designated_species_fkey_assessment_areas FOREIGN KEY (assessment_area_id) REFERENCES natura2000_areas (assessment_area_id), -- Currently limited to N2000. Can't reference base table 'assessment_areas'.
+	CONSTRAINT designated_species_fkey_species FOREIGN KEY (species_id) REFERENCES species
 );
 
 
@@ -236,14 +236,14 @@ CREATE TABLE nature.designated_species
  * -------------------
  * Table containing the species that can be present in a habitat type.
  */
-CREATE TABLE nature.species_to_habitats
+CREATE TABLE species_to_habitats
 (
 	species_id integer NOT NULL,
 	assessment_area_id integer NOT NULL,
 	goal_habitat_type_id integer NOT NULL,
 
 	CONSTRAINT species_to_habitats_pkey PRIMARY KEY (species_id, assessment_area_id, goal_habitat_type_id),
-	CONSTRAINT species_to_habitats_fkey_species FOREIGN KEY (species_id) REFERENCES nature.species,
-	CONSTRAINT species_to_habitats_fkey_assessment_areas FOREIGN KEY (assessment_area_id) REFERENCES nature.natura2000_areas (assessment_area_id), -- Currently limited to N2000. Can't reference base table 'assessment_areas'.
-	CONSTRAINT species_to_habitats_fkey_habitat_types FOREIGN KEY (goal_habitat_type_id) REFERENCES nature.habitat_types (habitat_type_id)
+	CONSTRAINT species_to_habitats_fkey_species FOREIGN KEY (species_id) REFERENCES species,
+	CONSTRAINT species_to_habitats_fkey_assessment_areas FOREIGN KEY (assessment_area_id) REFERENCES natura2000_areas (assessment_area_id), -- Currently limited to N2000. Can't reference base table 'assessment_areas'.
+	CONSTRAINT species_to_habitats_fkey_habitat_types FOREIGN KEY (goal_habitat_type_id) REFERENCES habitat_types (habitat_type_id)
 );

--- a/source/modules/src/main/sql/database-modules/nature_habitats_and_species/03-functions.sql
+++ b/source/modules/src/main/sql/database-modules/nature_habitats_and_species/03-functions.sql
@@ -7,11 +7,11 @@
  * - Sensitive: 1400 <= KDW < 2400
  * - Lowly/not sensitive: >= 2400
  */
-CREATE OR REPLACE FUNCTION nature.ae_critical_deposition_classification(critical_deposition posreal)
+CREATE OR REPLACE FUNCTION ae_critical_deposition_classification(critical_deposition posreal)
 	RETURNS text AS
 $BODY$
 DECLARE
-	result nature.critical_deposition_classification;
+	result critical_deposition_classification;
 BEGIN
 	IF (critical_deposition < 1400) THEN
 		result = 'high_sensitivity';


### PR DESCRIPTION
From now on the modules need to be imported using the `import_common_into_schema` which makes it possible to choose the schema name yourself.


