### PR TITLE
Speedup the receptors_to_critical_deposition_areas build

### DIFF
--- a/source/modules/src/data/sql/database-modules/build_grid_receptors_to/build-multi-zoom-level.sql
+++ b/source/modules/src/data/sql/database-modules/build_grid_receptors_to/build-multi-zoom-level.sql
@@ -19,7 +19,7 @@ COMMIT;
 SELECT system.raise_notice('Build: receptors_to_critical_deposition_areas @ ' || timeofday());
 
 BEGIN;
-{multithread on: SELECT assessment_area_id FROM nature.assessment_areas ORDER BY assessment_area_id}
+{multithread on: SELECT assessment_area_id, critical_deposition_area_type FROM nature.assessment_areas CROSS JOIN (SELECT unnest(enum_range(null::nature.critical_deposition_area_type)) AS critical_deposition_area_type) AS types	ORDER BY assessment_area_id, critical_deposition_area_type }
 	INSERT INTO grid.receptors_to_critical_deposition_areas (assessment_area_id, type, critical_deposition_area_id, receptor_id, zoom_level, surface, receptor_habitat_coverage)
 	SELECT
 		assessment_area_id,
@@ -32,6 +32,8 @@ BEGIN;
 
 		FROM grid.build_receptors_to_critical_deposition_areas_view
 		
-		WHERE assessment_area_id = {assessment_area_id};
+		WHERE
+			assessment_area_id = {assessment_area_id}
+			AND type = '{critical_deposition_area_type}'
 {/multithread}
 COMMIT;

--- a/source/modules/src/data/sql/database-modules/build_grid_receptors_to/build-single-zoom-level.sql
+++ b/source/modules/src/data/sql/database-modules/build_grid_receptors_to/build-single-zoom-level.sql
@@ -18,7 +18,7 @@ COMMIT;
 SELECT system.raise_notice('Build: receptors_to_critical_deposition_areas @ ' || timeofday());
 
 BEGIN;
-{multithread on: SELECT assessment_area_id FROM nature.assessment_areas ORDER BY assessment_area_id}
+{multithread on: SELECT assessment_area_id, critical_deposition_area_type FROM nature.assessment_areas CROSS JOIN (SELECT unnest(enum_range(null::nature.critical_deposition_area_type)) AS critical_deposition_area_type) AS types	ORDER BY assessment_area_id, critical_deposition_area_type }
 	INSERT INTO grid.receptors_to_critical_deposition_areas (assessment_area_id, type, critical_deposition_area_id, receptor_id, surface, receptor_habitat_coverage)
 	SELECT
 		assessment_area_id,
@@ -30,6 +30,9 @@ BEGIN;
 
 		FROM grid.build_receptors_to_critical_deposition_areas_view
 		
-		WHERE assessment_area_id = {assessment_area_id};
+		WHERE
+			assessment_area_id = {assessment_area_id}
+			AND type = '{critical_deposition_area_type}'
+	;
 {/multithread}
 COMMIT;


### PR DESCRIPTION
Split up the (multi threaded) receptors_to_critical_deposition_areas build even further. With the priority-habitats added (in GRIP) the build still gets stuck.