### PR TITLE
fix nature-grid build.

### DIFF
--- a/source/modules/src/data/sql/database-modules/build_grid/build.sql
+++ b/source/modules/src/data/sql/database-modules/build_grid/build.sql
@@ -1,5 +1,11 @@
 SELECT system.raise_notice('Build: geometry_of_interests @ ' || timeofday());
-BEGIN; SELECT grid.ae_build_geometry_of_interests(); COMMIT;
+BEGIN; 
+	SET search_path TO 'grid', 'public'; 
+	SELECT grid.ae_build_geometry_of_interests(); 
+COMMIT;
 
 SELECT system.raise_notice('Build: hexagons and receptors @ ' || timeofday());
-BEGIN; SELECT grid.ae_build_hexagons_and_receptors(); COMMIT;
+BEGIN; 
+	SET search_path TO 'grid', 'public'; 
+	SELECT grid.ae_build_hexagons_and_receptors(); 
+COMMIT;

--- a/source/modules/src/data/sql/database-modules/build_grid_receptors_to/build-multi-zoom-level.sql
+++ b/source/modules/src/data/sql/database-modules/build_grid_receptors_to/build-multi-zoom-level.sql
@@ -1,6 +1,6 @@
 SELECT system.raise_notice('Build: receptors_to_assessment_areas @ ' || timeofday());
 
-{multithread on: SELECT assessment_area_id FROM nature.assessment_areas ORDER BY assessment_area_id}
+{multithread on: SELECT assessment_area_id FROM nature.assessment_areas WHERE type = 'natura2000_area' ORDER BY assessment_area_id}
 
 	-- For the executed multi thread code execution the import_common_into_schema search path schema is not set.
 	-- This is the only way I could find to make this code work.
@@ -23,7 +23,16 @@ SELECT system.raise_notice('Build: receptors_to_assessment_areas @ ' || timeofda
 
 SELECT system.raise_notice('Build: receptors_to_critical_deposition_areas @ ' || timeofday());
 
-{multithread on: SELECT assessment_area_id, critical_deposition_area_type FROM nature.assessment_areas CROSS JOIN (SELECT unnest(enum_range(null::public.critical_deposition_area_type)) AS critical_deposition_area_type) AS types ORDER BY assessment_area_id, critical_deposition_area_type }
+{multithread on: SELECT 
+					assessment_area_id, 
+					critical_deposition_area_type 
+
+					FROM nature.assessment_areas 
+						CROSS JOIN (SELECT unnest(enum_range(null::public.critical_deposition_area_type)) AS critical_deposition_area_type) AS types 
+
+					WHERE type = 'natura2000_area' 
+
+					ORDER BY assessment_area_id, critical_deposition_area_type}
 
 	-- For the executed multi thread code execution the import_common_into_schema search path schema is not set.
 	-- This is the only way I could find to make this code work.


### PR DESCRIPTION
Fix nature-grid build by adding set search_path to geometry_of_interest and building hexagons_and_receptors.
I guess it was "broken" with a previous change. 