### PR TITLE
Adjust ae_determine_receptor_ids_from_receptor_with_radius

### DIFF
--- a/source/modules/src/main/sql/database-modules/build_grid/02-geometric-utils/02-receptors.sql
+++ b/source/modules/src/main/sql/database-modules/build_grid/02-geometric-utils/02-receptors.sql
@@ -257,7 +257,7 @@ BEGIN
 			return_receptor_id [6] = receptor_id + (radius + t)     * number_of_hexagons_in_a_row + floor((radius - t) / 2.0);
 
 			FOR i IN 1..6 LOOP
-				IF (return_receptor_id[i] >= 0 AND return_receptor_id[i] <= receptor_id_max) THEN
+				IF (return_receptor_id[i] > 0 AND return_receptor_id[i] <= receptor_id_max) THEN
 					IF (i = 1) 	THEN IF (ceil(t / 2.0) < from_left) THEN RETURN NEXT return_receptor_id[i]; END IF;
 					ELSIF (i = 2)	THEN IF (ceil(radius / 2.0) < from_left) THEN RETURN NEXT return_receptor_id[i]; END IF;
 					ELSIF (i = 3) 	THEN IF (ceil((radius - t) / 2.0) < from_left) THEN RETURN NEXT return_receptor_id[i]; END IF;
@@ -278,7 +278,7 @@ BEGIN
 			return_receptor_id [6] = receptor_id + (radius + t)     * number_of_hexagons_in_a_row + ceil((radius - t) / 2.0);
 
 			FOR i IN 1..6 LOOP
-				IF (return_receptor_id[i] >= 0 AND return_receptor_id[i] <= receptor_id_max) THEN
+				IF (return_receptor_id[i] > 0 AND return_receptor_id[i] <= receptor_id_max) THEN
 					IF (i = 1) 	THEN IF (floor(t / 2.0) < from_left) THEN RETURN NEXT return_receptor_id[i]; END IF;
 					ELSIF (i = 2)	THEN IF (floor(radius / 2.0) < from_left) THEN RETURN NEXT return_receptor_id[i]; END IF;
 					ELSIF (i = 3) 	THEN IF (floor((radius - t) / 2.0) < from_left) THEN RETURN NEXT return_receptor_id[i]; END IF;

--- a/source/modules/src/main/sql/database-modules/build_grid/02-geometric-utils/unittest/receptors.sql
+++ b/source/modules/src/main/sql/database-modules/build_grid/02-geometric-utils/unittest/receptors.sql
@@ -71,7 +71,7 @@ BEGIN
 		-- Because the set in tmp_calculated_receptor_ids is an ordered and distinct set of integers, the following holds: id(x+n) >= id(x) + n.
 		-- Furthermore when there are no "holes" in the set, the following holds: id(x+n) = id(x) + n. So we only need the first and last id in the set
 		-- and the number of id's.
-		PERFORM system.assert_equals(first_vertically_projected + number_of_distinct_rows - 1, last_vertically_projected, 'failed at receptor ' || receptor_id);
+		PERFORM system.assert_equals(first_vertically_projected + number_of_distinct_rows - 1, last_vertically_projected, 'failed at receptor ' || receptor_id || ', radius ' || radius);
 
 		DROP TABLE tmp_calculated_receptor_ids;
 


### PR DESCRIPTION
Function is adjusted to no longer return 0 as receptor_id. 
Turns out, with a receptor_id of 3907993, and a radius of 1409, the adjusted unittest would fail. This because 0 would be returned, and since that doesn't really hold with the assumption of the test adjusted the function to void this (0 isn't a receptor ID we want in any case).

Unfortunately the test didn't supply the radius directly and is using random numbers, so had to create a query that would do all radius values between 1 and 1530 to figure out the value that was causing the error...