### PR TITLE
Remove schema prefix

### DIFF
--- a/source/modules/src/data/sql/database-modules/build_grid/build.sql
+++ b/source/modules/src/data/sql/database-modules/build_grid/build.sql
@@ -1,7 +1,7 @@
 SET search_path TO 'grid', 'public';
 SELECT system.raise_notice('Build: geometry_of_interests @ ' || timeofday());
-BEGIN; SELECT grid.ae_build_geometry_of_interests(); COMMIT;
+BEGIN; SELECT ae_build_geometry_of_interests(); COMMIT;
 
 SET search_path TO 'grid', 'public';
 SELECT system.raise_notice('Build: hexagons and receptors @ ' || timeofday());
-BEGIN; SELECT grid.ae_build_hexagons_and_receptors(); COMMIT;
+BEGIN; SELECT ae_build_hexagons_and_receptors(); COMMIT;

--- a/source/modules/src/data/sql/database-modules/build_grid/build.sql
+++ b/source/modules/src/data/sql/database-modules/build_grid/build.sql
@@ -1,7 +1,5 @@
-SET search_path TO 'grid', 'public';
 SELECT system.raise_notice('Build: geometry_of_interests @ ' || timeofday());
 BEGIN; SELECT ae_build_geometry_of_interests(); COMMIT;
 
-SET search_path TO 'grid', 'public';
 SELECT system.raise_notice('Build: hexagons and receptors @ ' || timeofday());
 BEGIN; SELECT ae_build_hexagons_and_receptors(); COMMIT;


### PR DESCRIPTION
The prefix has been removed to force the module to be loaded via `import_common_into_schema`. An error had now crept into Monitor, preventing the build from finding the `province_land_borders` table.
We don't need the `search_path` statements if we use `import_common_into_schema`.