### PR TITLE
Don't load abroad_data for Monitor UI.

### DIFF
--- a/source/modules/src/data/sql/database-modules/build_grid/build.sql
+++ b/source/modules/src/data/sql/database-modules/build_grid/build.sql
@@ -1,5 +1,7 @@
+SET search_path TO 'grid', 'public';
 SELECT system.raise_notice('Build: geometry_of_interests @ ' || timeofday());
 BEGIN; SELECT grid.ae_build_geometry_of_interests(); COMMIT;
 
+SET search_path TO 'grid', 'public';
 SELECT system.raise_notice('Build: hexagons and receptors @ ' || timeofday());
 BEGIN; SELECT grid.ae_build_hexagons_and_receptors(); COMMIT;

--- a/source/modules/src/data/sql/database-modules/grid/dataset_26.sql
+++ b/source/modules/src/data/sql/database-modules/grid/dataset_26.sql
@@ -1,2 +1,2 @@
-BEGIN; SELECT system.load_table('receptors', '{data_folder}/common/grid/26/grid.receptors_20260519.txt'); COMMIT;
-BEGIN; SELECT system.load_table('hexagons', '{data_folder}/common/grid/26/grid.hexagons_20260519.txt'); COMMIT;
+BEGIN; SELECT system.load_table('receptors', '{data_folder}/common/grid/26/grid.receptors_20260717.txt'); COMMIT;
+BEGIN; SELECT system.load_table('hexagons', '{data_folder}/common/grid/26/grid.hexagons_20260717.txt'); COMMIT;

--- a/source/modules/src/data/sql/database-modules/grid_receptors_to/multi-zoom-level/dataset_26.sql
+++ b/source/modules/src/data/sql/database-modules/grid_receptors_to/multi-zoom-level/dataset_26.sql
@@ -1,4 +1,4 @@
 BEGIN; SELECT system.load_table('receptors_to_assessment_areas', '{data_folder}/common/grid_receptors_to/multi-zoom-level/26/grid.receptors_to_assessment_areas_20260717.txt'); COMMIT;
-BEGIN; SELECT system.load_table('receptors_to_critical_deposition_areas', '{data_folder}/common/grid_receptors_to/multi-zoom-level/26/grid.receptors_to_critical_deposition_areas_20260717.txt');
+BEGIN; SELECT system.load_table('receptors_to_critical_deposition_areas', '{data_folder}/common/grid_receptors_to/multi-zoom-level/26/grid.receptors_to_critical_deposition_areas_20260720.txt');
 
 {import_common 'database-modules/grid_receptors_to/refresh_materialized_views.sql'}

--- a/source/modules/src/data/sql/database-modules/grid_receptors_to/multi-zoom-level/dataset_26.sql
+++ b/source/modules/src/data/sql/database-modules/grid_receptors_to/multi-zoom-level/dataset_26.sql
@@ -1,4 +1,4 @@
-BEGIN; SELECT system.load_table('receptors_to_assessment_areas', '{data_folder}/common/grid_receptors_to/multi-zoom-level/26/grid.receptors_to_assessment_areas_20260622.txt'); COMMIT;
-BEGIN; SELECT system.load_table('receptors_to_critical_deposition_areas', '{data_folder}/common/grid_receptors_to/multi-zoom-level/26/grid.receptors_to_critical_deposition_areas_20260622.txt');
+BEGIN; SELECT system.load_table('receptors_to_assessment_areas', '{data_folder}/common/grid_receptors_to/multi-zoom-level/26/grid.receptors_to_assessment_areas_20260717.txt'); COMMIT;
+BEGIN; SELECT system.load_table('receptors_to_critical_deposition_areas', '{data_folder}/common/grid_receptors_to/multi-zoom-level/26/grid.receptors_to_critical_deposition_areas_20260717.txt');
 
 {import_common 'database-modules/grid_receptors_to/refresh_materialized_views.sql'}


### PR DESCRIPTION
- new grid-and nature generated import-files without the abroad data loaded.
- Removal of 13 zl1 receptors from the generated receptor_to import-files. These 13 hexagons intersect with relevant nature varying from 0.026 to 0.0003 m2 and have no calculated deposition. It is descided to remove these zl1 receptors as relevant receptors for Monitor and Calculator.
- fix build (won't build without the set_path to grid and public) 